### PR TITLE
Fixed PHP 8.2 issue

### DIFF
--- a/lib/ApiClient.php
+++ b/lib/ApiClient.php
@@ -353,7 +353,7 @@ class ApiClient
 
                 $key = $h[0];
             } else {
-                if ($h[0][0] === "\t") {
+                if (strlen($h[0]) > 0 && $h[0][0] === "\t") {
                     $headers[$key] .= "\r\n\t".trim($h[0]);
                 } elseif (!$key) {
                     $headers[0] = trim($h[0]);


### PR DESCRIPTION
If the header is empty, do not check the first character